### PR TITLE
[FI-51] feat payment service paid 

### DIFF
--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/ctrl/BookingCtrl.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/ctrl/BookingCtrl.java
@@ -32,4 +32,15 @@ public class BookingCtrl {
         bookingSv.cancelBooking(bookingSq);
         return ResponseEntity.ok().build();
     }
+
+    // [추가] 예매 확정 API
+    // 요청 예시: PATCH /bookings/1/confirm?paymentKey=toss_1234
+    @PatchMapping("/{bookingSq}/confirm")
+    public ResponseEntity<Void> confirmBooking(
+            @PathVariable Long bookingSq,
+            @RequestParam String paymentKey
+    ) {
+        bookingSv.confirmBooking(bookingSq, paymentKey);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Booking.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Booking.java
@@ -111,7 +111,15 @@ public class Booking {
     }
 
     // 3. 예매 확정 (결제 완료 시)
-    public void confirm() {
+    public void confirm(String paymentKey) {
         this.bookingStatus = BookingStatus.CONFIRMED;
+        this.paymentKey = paymentKey;          // PG사에서 받은 결제 키 저장
+        this.approvedAt = LocalDateTime.now(); // 승인 시간 기록
+        this.paymentMethod = "CARD";           // (나중에 파라미터로 확장 가능)
+
+        // ★ 하위 티켓들도 모두 '결제됨(PAID)' 상태로 변경
+        for (Ticket ticket : this.tickets) {
+            ticket.paid();
+        }
     }
 }

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Ticket.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Ticket.java
@@ -45,8 +45,12 @@ public class Ticket {
     @JoinColumn(name = "booking_sq", nullable = false)
     private Booking booking;
 
-
     // 비즈니스 로직
+
+    // [추가] 결제 완료 처리 (Booking에서 호출)
+    public void paid() {
+        this.ticketStatus = TicketStatus.PAID;
+    }
     // [추가] 티켓 취소 비즈니스 로직
     public void cancel() {
         this.ticketStatus = TicketStatus.CANCELLED; // 4번 상태로 변경

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/sv/BookingSv.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/sv/BookingSv.java
@@ -41,4 +41,18 @@ public class BookingSv {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예매 번호입니다: " + bookingSq));
         booking.cancel(); // status: 0 -> 2
     }
+
+    // 4. 예매 확정 (결제 승인)
+    @Transactional
+    public void confirmBooking(Long bookingSq, String paymentKey) {
+        // 1. 예매 내역 조회
+        Booking booking = bookingRepo.findById(bookingSq)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예매 번호입니다: " + bookingSq));
+
+        // 2. [TODO] 추후 PG사 승인 검증 로직 추가 (PaymentClient.confirm...)
+        // 지금은 무조건 결제 성공이라고 가정합니다.
+
+        // 3. 상태 변경 (Pending -> Confirmed)
+        booking.confirm(paymentKey);
+    }
 }


### PR DESCRIPTION
- Ticket Entity 수정: 결제 완료 시 티켓 상태를 PAID로 변경하는 paid() 편의 메서드 추가
- Booking Entity 수정: confirm() 메서드 보완 (결제 키 저장, 승인 일시 기록, 하위 티켓 상태 일괄 변경 로직 추가)
- BookingService 구현: confirmBooking(Long bookingSq, String paymentKey) 트랜잭션 메서드 구현
- BookingController 구현: 예매 확정을 위한 PATCH /bookings/{bookingSq}/confirm API 엔드포인트 추가
- API 테스트: HTTP Client(.http)를 활용한 예매 생성 -> 확정 흐름 테스트