### PR TITLE
[FI-53] feat payment service deduplication

### DIFF
--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/repo/TicketRepo.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/repo/TicketRepo.java
@@ -1,0 +1,13 @@
+package io.why503.paymentservice.domain.booking.repo;
+
+import io.why503.paymentservice.domain.booking.model.ett.Ticket;
+import io.why503.paymentservice.domain.booking.model.type.TicketStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+
+public interface TicketRepo extends JpaRepository<Ticket, Long> {
+
+    // "특정 좌석(showingSeatSq)이면서 + 상태가 목록(statuses) 중 하나라도 겹치면 -> true 반환"
+    boolean existsByShowingSeatSqAndTicketStatusIn(Long showingSeatSq, Collection<TicketStatus> statuses);
+}


### PR DESCRIPTION
예매 생성 요청 시, 해당 좌석이 이미 선점(RESERVED)되었거나 결제(PAID)된 상태인지 확인하여 중복 예매를 원천 차단하는 유효성 검사(Validation) 기능을 구현합니다.

- TicketRepo 생성: 특정 좌석이 RESERVED 또는 PAID 상태인지 확인하는 existsByShowingSeatSqAndTicketStatusIn 쿼리 메서드 작성
- BookingService 수정: createBooking 메서드 진입 시, 요청된 모든 좌석에 대해 중복 여부 검사 로직 추가
- Exception 처리: 이미 예매된 좌석일 경우 예외 발생 및 에러 메시지 반환 ("이미 선택된 좌석입니다.")
- Test: 선점된 좌석으로 다시 예매 요청 시 정상적으로 실패하는지 API 테스트