### PR TITLE
[FI-54] feat paymentService lock

### DIFF
--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/dto/BookingReqDto.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/dto/BookingReqDto.java
@@ -1,11 +1,14 @@
 package io.why503.paymentservice.domain.booking.model.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 import java.util.List;
 
 @Getter
+@Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class BookingReqDto {
     private Long userSq;
     private Integer totalAmount;

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/dto/TicketReqDto.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/dto/TicketReqDto.java
@@ -1,10 +1,12 @@
 package io.why503.paymentservice.domain.booking.model.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class TicketReqDto {
     private Long showingSeatSq;
     private Integer originalPrice;

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Ticket.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/model/ett/Ticket.java
@@ -55,4 +55,14 @@ public class Ticket {
     public void cancel() {
         this.ticketStatus = TicketStatus.CANCELLED; // 4번 상태로 변경
     }
+
+    // 저장 전 null 방어 로직
+    @PrePersist
+    public void prePersist() {
+        if (this.originalPrice == null) this.originalPrice = 0;
+        if (this.discountAmount == null) this.discountAmount = 0;
+        if (this.finalPrice == null) this.finalPrice = 0;
+        if (this.ticketStatus == null) this.ticketStatus = TicketStatus.AVAILABLE;
+        if (this.ticketUuid == null) this.ticketUuid = java.util.UUID.randomUUID().toString();
+    }
 }

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/repo/TicketRepo.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/booking/repo/TicketRepo.java
@@ -2,12 +2,27 @@ package io.why503.paymentservice.domain.booking.repo;
 
 import io.why503.paymentservice.domain.booking.model.ett.Ticket;
 import io.why503.paymentservice.domain.booking.model.type.TicketStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface TicketRepo extends JpaRepository<Ticket, Long> {
 
     // "특정 좌석(showingSeatSq)이면서 + 상태가 목록(statuses) 중 하나라도 겹치면 -> true 반환"
     boolean existsByShowingSeatSqAndTicketStatusIn(Long showingSeatSq, Collection<TicketStatus> statuses);
+
+    //  비관적 락(Pessimistic Lock) 적용
+    // - PESSIMISTIC_WRITE: 트랜잭션 종료 시까지 쓰기/읽기 차단 (배타적 락)
+    // - 데이터가 없으면 '빈 공간'에 락을 걸어 INSERT를 막음 (Gap Lock)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Ticket t where t.showingSeatSq = :seatSq and t.ticketStatus in :statuses")
+    List<Ticket> findWithLockByShowingSeatSqAndTicketStatusIn(
+            @Param("seatSq") Long seatSq,
+            @Param("statuses") Collection<TicketStatus> statuses
+    );
 }

--- a/FLOWIN/payment-service/src/test/java/io/why503/paymentservice/domain/booking/sv/ConcurrencyTest.java
+++ b/FLOWIN/payment-service/src/test/java/io/why503/paymentservice/domain/booking/sv/ConcurrencyTest.java
@@ -1,0 +1,100 @@
+package io.why503.paymentservice.domain.booking.sv;
+
+import io.why503.paymentservice.domain.booking.model.dto.BookingReqDto;
+import io.why503.paymentservice.domain.booking.model.dto.TicketReqDto;
+import io.why503.paymentservice.domain.booking.repo.BookingRepo;
+import io.why503.paymentservice.domain.booking.repo.TicketRepo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "eureka.client.enabled=false",
+        "eureka.client.register-with-eureka=false",
+        "eureka.client.fetch-registry=false"
+})
+class ConcurrencyTest {
+
+    @Autowired
+    private BookingSv bookingSv;
+
+    @Autowired
+    private BookingRepo bookingRepo;
+
+    @Autowired
+    private TicketRepo ticketRepo;
+
+    @AfterEach
+    void tearDown() {
+        // 테스트가 끝나면 DB를 깨끗하게 비워줍니다.
+        // (Ticket이 Booking을 참조하므로 Booking 먼저 지우거나 Cascade 설정에 따라 다름)
+        // 안전하게 Ticket -> Booking 순서로 삭제
+        ticketRepo.deleteAll();
+        bookingRepo.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동시에 2명이 같은 좌석(100번) 예매 시도 -> 1명만 성공해야 한다.")
+    void bookingConcurrencyTest() throws InterruptedException {
+        // given
+        int threadCount = 2; // 동시에 2명 접속 시뮬레이션
+
+        // 멀티스레드 작업을 도와주는 녀석들 (32개 스레드 풀 생성)
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        // 2개의 작업이 모두 끝날 때까지 메인 스레드를 대기시키는 녀석
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 성공 횟수와 실패 횟수를 세는 변수 (동시성 환경에서도 안전한 AtomicInteger 사용)
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // 테스트 데이터 준비 (좌석 ID: 100L)
+        TicketReqDto ticketReq = TicketReqDto.builder().showingSeatSq(100L).build();
+        BookingReqDto req = BookingReqDto.builder()
+                .userSq(1L)
+                .tickets(List.of(ticketReq)) // 100번 좌석 요청
+                .build();
+
+        // when (동시 요청 시작!)
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 예매 시도!
+                    bookingSv.createBooking(req);
+                    // 에러 안 나면 성공 카운트 증가
+                    successCount.getAndIncrement();
+//                    System.out.println("성공!");
+                } catch (Exception e) {
+                    // 에러 나면 실패 카운트 증가
+                    failCount.getAndIncrement();
+//                    System.out.println("실패: " + e.getMessage());
+                } finally {
+                    // 성공하든 실패하든 작업 끝났다고 알림
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 2명의 스레드가 다 끝날 때까지 여기서 기다림
+        latch.await();
+
+        // then (검증)
+//        System.out.println("최종 성공 횟수: " + successCount.get());
+//        System.out.println("최종 실패 횟수: " + failCount.get());
+
+        // ★ 핵심 검증: 성공은 딱 1번이어야 하고, 실패도 딱 1번이어야 함
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
현재 exists(조회)와 save(저장) 사이의 시차로 인해, 트래픽 급증 시 중복 예매가 발생할 위험이 있습니다. 이를 해결하기 위해 JPA의 Lock(PESSIMISTIC_WRITE)을 사용하여, 트랜잭션이 끝날 때까지 해당 좌석 row에 배타적 락(Exclusive Lock)을 걸어 데이터 정합성을 보장합니다.

- TicketRepo: Lock(PESSIMISTIC_WRITE) 옵션이 적용된 조회 메서드 작성
- BookingSv: 단순 조회 로직을 락(Lock)을 동반한 조회 로직으로 변경
- Test: 동시성 제어 동작 및 예외 처리 확인
