### PR TITLE
[FI-562] Show 장르, 조회 추가

### DIFF
--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/roundSeat/model/dto/response/SeatReserveResponse.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/roundSeat/model/dto/response/SeatReserveResponse.java
@@ -15,6 +15,7 @@ public record SeatReserveResponse(
 
         String showName,        // 공연명
         String hallName, // 공연장명
-        LocalDateTime roundDt // 회차일시
+        LocalDateTime roundDt, // 회차일시
+        String genre            //장르
 ) {
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/controller/ShowController.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/controller/ShowController.java
@@ -3,6 +3,8 @@ package io.why503.performanceservice.domain.show.controller;
 import io.why503.performanceservice.domain.show.model.dto.request.ShowCreateWithSeatPolicyRequest;
 import io.why503.performanceservice.domain.show.model.dto.request.ShowRequest;
 import io.why503.performanceservice.domain.show.model.dto.response.ShowResponse;
+import io.why503.performanceservice.domain.show.model.enums.ShowCategory;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import io.why503.performanceservice.domain.show.service.ShowService;
 import io.why503.performanceservice.global.error.ErrorCode;
 import io.why503.performanceservice.global.error.exception.BusinessException;
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * Show Controller
@@ -75,4 +79,25 @@ public class ShowController {
         if (authorization == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);        }
     }
+
+
+    // 카테고리별 조회
+    // shows/category?category=CONCERT
+    @GetMapping("/category")
+    public ResponseEntity<List<ShowResponse>> getShowsByCategory(
+            @RequestParam("category") ShowCategory category
+    ) {
+        return ResponseEntity.ok(showService.findShowsByCategory(category));
+    }
+
+    // 카테고리 + 장르 조회
+    // shows/search?category=MUSICAL&genre=THRILLER
+    @GetMapping("/search")
+    public ResponseEntity<List<ShowResponse>> getShowsByCategoryAndGenre(
+            @RequestParam("category") ShowCategory category,
+            @RequestParam("genre") ShowGenre genre
+    ) {
+        return ResponseEntity.ok(showService.findShowsByCategoryAndGenre(category, genre));
+    }
+
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/dto/request/ShowRequest.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/dto/request/ShowRequest.java
@@ -7,6 +7,7 @@
 package io.why503.performanceservice.domain.show.model.dto.request;
 
 import io.why503.performanceservice.domain.show.model.enums.ShowCategory;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -20,6 +21,7 @@ public record ShowRequest(
         @NotBlank String showRunningTime,          // 러닝타임
         @NotBlank String showViewingAge,        // 관람 등급
         @NotNull ShowCategory showCategory,          // 공연 카테고리
+        @NotNull ShowGenre showGenre,             //공연 장르
         @NotBlank String showStatus,            //공연 상태
         @NotNull Long hallSq         // 공연장 식별자
 ) { }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/dto/response/ShowResponse.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/dto/response/ShowResponse.java
@@ -7,6 +7,7 @@
  */
 package io.why503.performanceservice.domain.show.model.dto.response;
 
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -25,6 +26,7 @@ public record ShowResponse(
         @NotBlank String viewingAge,        // 관람 등급
 
         @NotNull ShowCategory category,     // 공연 카테고리
+        @NotNull ShowGenre genre,           //공연 장르
         @NotNull ShowStatus showStatus,       // 공연 상태
 
         @NotNull Long concertHallSq,        // 공연장 식별자

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/entity/ShowEntity.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/entity/ShowEntity.java
@@ -11,6 +11,7 @@
 package io.why503.performanceservice.domain.show.model.entity;
 
 import io.why503.performanceservice.domain.hall.model.entity.HallEntity;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -55,6 +56,10 @@ public class ShowEntity {
     private ShowCategory category;              // 공연 카테고리 코드
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "genre", nullable = false)
+    private ShowGenre genre;            //공연 장르
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ShowStatus status;              // 공연 상태 코드
 
@@ -74,6 +79,7 @@ public class ShowEntity {
             String runningTime,
             String viewingAge,
             ShowCategory category, // int category -> ShowCategory category
+            ShowGenre genre,
             HallEntity hall,
             Long companySq) {
         this.name = name;
@@ -83,6 +89,7 @@ public class ShowEntity {
         this.runningTime = runningTime;
         this.viewingAge = viewingAge;
         this.category = category;
+        this.genre = genre;
         this.status = ShowStatus.SCHEDULED; // 기본값 설정 (Enum 직접 할당)
         this.hall = hall;
         this.companySq = companySq;
@@ -94,4 +101,5 @@ public class ShowEntity {
     public void changeStatus(ShowStatus newStatus) {
         this.status = newStatus;
     }
+    public void changeGenre(ShowGenre newGenre){ this.genre=newGenre;}
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/enums/ShowGenre.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/model/enums/ShowGenre.java
@@ -1,0 +1,29 @@
+package io.why503.performanceservice.domain.show.model.enums;
+
+public enum ShowGenre {
+    BALLAD,        //발라드
+    ROCK,          //락
+    METAL,         //메탈
+    HIPHOP,        //힙합
+    R_N_B,           //R&B
+    JAZZ,          //JAZZ
+    TROT,          //트로트
+    DRAMA,         //정극
+    COMEDY,        //코미디
+    ROMANCE,       //로맨스
+    THRILLER,      //스릴러
+    MYSTERY,       //미스테리
+    HISTORICAL,    //시대극
+    MONODRAMA,     //1인극
+    CREATIVE,      //창작뮤지컬
+    LICENSED,      //라이센스뮤지컬
+    ORIGINAL,      //오리지널 내한
+    ORCHESTRA,     //교향곡, 대규모 오케스트라
+    CONCERTO,      //협주곡, 독주자와 오케스트라
+    CHAMBER,       //실내악, 소규모 앙상블
+    RECITAL,       //독주
+    OPERA,         //오페라
+    VOCAL,         //성악
+    CHOIR;         //합창
+
+}

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/repository/ShowRepository.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/repository/ShowRepository.java
@@ -10,11 +10,20 @@
  */
 package io.why503.performanceservice.domain.show.repository;
 
+import io.why503.performanceservice.domain.show.model.enums.ShowCategory;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import io.why503.performanceservice.domain.show.model.entity.ShowEntity;
 
+import java.util.List;
+
 @Repository
 public interface ShowRepository extends JpaRepository<ShowEntity, Long> {
+
+    //카테고리별 공연 조회
+    List<ShowEntity> findByCategory(ShowCategory category);
+    //카테고리와 장르로 조회
+    List<ShowEntity> findByCategoryAndGenre(ShowCategory category, ShowGenre genre);
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/service/ShowService.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/service/ShowService.java
@@ -16,6 +16,10 @@ import io.why503.performanceservice.domain.show.model.dto.request.ShowCreateWith
 import io.why503.performanceservice.domain.show.model.dto.request.ShowRequest;
 import io.why503.performanceservice.domain.show.model.dto.response.ShowResponse;
 import io.why503.performanceservice.domain.show.model.entity.ShowEntity;
+import io.why503.performanceservice.domain.show.model.enums.ShowCategory;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
+
+import java.util.List;
 
 public interface ShowService {
 
@@ -36,4 +40,9 @@ public interface ShowService {
 
     //공연 단건 조회(round 생성용)
     ShowEntity findShowBySq(Long showSq);
+
+    //카테고리 조회
+    List<ShowResponse> findShowsByCategory(ShowCategory category);
+    //카테고리+장르 조회
+    List<ShowResponse> findShowsByCategoryAndGenre(ShowCategory category, ShowGenre genre);
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/service/impl/ShowServiceImpl.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/show/service/impl/ShowServiceImpl.java
@@ -9,6 +9,8 @@ import io.why503.performanceservice.domain.show.model.dto.request.ShowCreateWith
 import io.why503.performanceservice.domain.show.model.dto.request.ShowRequest;
 import io.why503.performanceservice.domain.show.model.dto.response.ShowResponse;
 import io.why503.performanceservice.domain.show.model.entity.ShowEntity;
+import io.why503.performanceservice.domain.show.model.enums.ShowCategory;
+import io.why503.performanceservice.domain.show.model.enums.ShowGenre;
 import io.why503.performanceservice.domain.show.repository.ShowRepository;
 import io.why503.performanceservice.domain.show.service.ShowService;
 import io.why503.performanceservice.domain.showseat.model.dto.request.SeatPolicyRequest;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -143,5 +146,30 @@ public class ShowServiceImpl implements ShowService {
             // 그 외 Feign 통신 에러 (서버 다운 등) -> 502 Bad Gateway
             throw new BusinessException(ErrorCode.USER_SERVICE_UNAVAILABLE);
         }
+    }
+    // 카테고리별 조회
+    @Override
+    public List<ShowResponse> findShowsByCategory(ShowCategory category) {
+        List<ShowEntity> shows = showRepository.findByCategory(category);
+
+        List<ShowResponse> list = new ArrayList<>();
+        for (ShowEntity show : shows) {
+            ShowResponse showResponse = showMapper.entityToResponse(show);
+            list.add(showResponse);
+        }
+        return list;
+    }
+
+    // 카테고리 + 장르 조회
+    @Override
+    public List<ShowResponse> findShowsByCategoryAndGenre(ShowCategory category, ShowGenre genre) {
+        List<ShowEntity> shows = showRepository.findByCategoryAndGenre(category, genre);
+
+        List<ShowResponse> list = new ArrayList<>();
+        for (ShowEntity show : shows) {
+            ShowResponse showResponse = showMapper.entityToResponse(show);
+            list.add(showResponse);
+        }
+        return list;
     }
 }

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/util/mapper/RoundSeatMapper.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/util/mapper/RoundSeatMapper.java
@@ -76,6 +76,7 @@ public class RoundSeatMapper {
 
                 // 공연 및 공연장 정보
                 .showName(show.getName())
+                .genre(show.getGenre().name())
                 .hallName(concertHallName)
                 .roundDt(round.getStartDt())
                 .build();

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/util/mapper/ShowMapper.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/util/mapper/ShowMapper.java
@@ -29,6 +29,7 @@ public class ShowMapper {
                 .viewingAge(request.showViewingAge())
                 .hall(hallEntity)
                 .category(request.showCategory())
+                .genre(request.showGenre())
                 .companySq(companySq)
                 .status(ShowStatus.valueOf(request.showStatus()))
                 .build();
@@ -47,6 +48,7 @@ public class ShowMapper {
                 entity.getRunningTime(),
                 entity.getViewingAge(),
                 entity.getCategory(),
+                entity.getGenre(),
                 entity.getStatus(),
                 entity.getHall().getSq(),
                 entity.getCompanySq()


### PR DESCRIPTION
## 목적
AI 추천 추가로 공연을 추천하기 위해선 각 카테고리에 대한 장르가 추가되어야 사용자에게 맞는 공연을 추천할 수 있어짐

## 변경 사항
* 엔티티에 공연 장르 추가
* 카테고리별 검색 추가
* 카테고리 + 장르 검색 추가
* payment에 넘겨주는 response에 공연 카테고리 추가

## 테스트 방법
포스트맨
