### PR TITLE
[FI-552] 예매 완료시 entryToken회수 이벤트 추가 및 performance 변경사항에 따 각 서비스 Feign 응답 구조 정렬

### DIFF
--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/payment/controller/PaymentViewController.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/payment/controller/PaymentViewController.java
@@ -7,6 +7,7 @@ import io.why503.paymentservice.domain.point.service.PointService;
 import io.why503.paymentservice.domain.ticket.model.enums.DiscountPolicy;
 import io.why503.paymentservice.global.client.PerformanceClient;
 import io.why503.paymentservice.global.client.ReservationClient;
+import io.why503.paymentservice.global.client.dto.request.SeatReserveRequest;
 import io.why503.paymentservice.global.client.dto.response.BookingResponse;
 import io.why503.paymentservice.global.client.dto.response.BookingSeatResponse;
 import io.why503.paymentservice.global.client.dto.response.RoundSeatResponse;
@@ -49,7 +50,8 @@ public class PaymentViewController {
                     .map(bookingSeatResponse -> bookingSeatResponse.roundSeatSq())
                     .toList();
 
-            List<RoundSeatResponse> seats = performanceClient.findRoundSeats(roundSeatSqs);
+            List<RoundSeatResponse> seats =
+            performanceClient.findRoundSeats(new SeatReserveRequest(roundSeatSqs));
 
             if (seats == null || seats.isEmpty()) {
                 throw PaymentExceptionFactory.paymentNotFound("예매된 좌석 정보를 찾을 수 없습니다.");

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/payment/service/impl/PaymentServiceImpl.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/payment/service/impl/PaymentServiceImpl.java
@@ -19,6 +19,7 @@ import io.why503.paymentservice.global.client.PerformanceClient;
 import io.why503.paymentservice.global.client.PgClient;
 import io.why503.paymentservice.global.client.ReservationClient;
 import io.why503.paymentservice.global.client.dto.request.PointUseRequest;
+import io.why503.paymentservice.global.client.dto.request.SeatReserveRequest;
 import io.why503.paymentservice.global.client.dto.response.BookingResponse;
 import io.why503.paymentservice.global.client.dto.response.BookingSeatResponse;
 import io.why503.paymentservice.global.client.dto.response.RoundSeatResponse;
@@ -105,7 +106,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .map(seat -> seat.roundSeatSq())
                 .toList();
 
-        List<RoundSeatResponse> seatDetails = performanceClient.findRoundSeats(seatIds);
+        List<RoundSeatResponse> seatDetails = performanceClient.findRoundSeats(new SeatReserveRequest(seatIds));
         Map<Long, RoundSeatResponse> seatMap = seatDetails.stream()
                 .collect(Collectors.toMap(
                         data -> data.roundSeatSq(),
@@ -170,7 +171,7 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         try {
-            performanceClient.confirmRoundSeats(userSq, seatIds);
+            performanceClient.confirmRoundSeats(userSq, new SeatReserveRequest(seatIds));
             reservationClient.confirmPaid(userSq, booking.sq());
 
         } catch (Exception e) {
@@ -312,7 +313,7 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         if (booking != null && !cancelSeatIds.isEmpty()) {
-            performanceClient.cancelRoundSeats(cancelSeatIds);
+            performanceClient.cancelRoundSeats(userSq, new SeatReserveRequest(cancelSeatIds));
             reservationClient.refundSeats(userSq, payment.getBookingSq(), cancelSeatIds);
             ticketService.resetTickets(cancelSeatIds);
         }

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/ticket/service/impl/TicketServiceImpl.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/domain/ticket/service/impl/TicketServiceImpl.java
@@ -10,6 +10,7 @@ import io.why503.paymentservice.domain.ticket.model.enums.DiscountPolicy;
 import io.why503.paymentservice.domain.ticket.repository.TicketRepository;
 import io.why503.paymentservice.domain.ticket.service.TicketService;
 import io.why503.paymentservice.global.client.PerformanceClient;
+import io.why503.paymentservice.global.client.dto.request.SeatReserveRequest;
 import io.why503.paymentservice.global.client.dto.response.BookingSeatResponse;
 import io.why503.paymentservice.global.client.dto.response.RoundSeatResponse;
 import lombok.RequiredArgsConstructor;
@@ -137,7 +138,8 @@ public class TicketServiceImpl implements TicketService {
                 .toList();
 
         List<Ticket> tickets = ticketRepository.findAllByRoundSeatSqIn(roundSeatSqs);
-        List<RoundSeatResponse> seatDetails = performanceClient.findRoundSeats(roundSeatSqs);
+        List<RoundSeatResponse> seatDetails =
+        performanceClient.findRoundSeats(new SeatReserveRequest(roundSeatSqs));
 
         Map<Long, RoundSeatResponse> seatMap = seatDetails.stream()
                 .collect(Collectors.toMap(seat -> seat.roundSeatSq(), Function.identity()));

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/global/client/PerformanceClient.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/global/client/PerformanceClient.java
@@ -1,5 +1,6 @@
 package io.why503.paymentservice.global.client;
 
+import io.why503.paymentservice.global.client.dto.request.SeatReserveRequest;
 import io.why503.paymentservice.global.client.dto.response.RoundSeatResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
@@ -16,20 +17,25 @@ public interface PerformanceClient {
     @PostMapping("/round-seats/reserve")
     List<RoundSeatResponse> reserveRoundSeats(
             @RequestHeader("X-USER-SQ") Long userSq,
-            @RequestBody List<Long> roundSeatSqs
+            @RequestBody SeatReserveRequest request
     );
 
     // 선점 기한 만료 또는 예매 취소 시 좌석 선점 해제 요청
     @PostMapping("/round-seats/cancel")
-    void cancelRoundSeats(@RequestBody List<Long> roundSeatSqs);
+    void cancelRoundSeats(
+            @RequestHeader("X-USER-SQ") Long userSq,
+            @RequestBody SeatReserveRequest request
+    );
 
     // 결제 완료 시 선점된 좌석을 최종 예매 확정 상태로 변경
     @PostMapping("/round-seats/confirm")
     void confirmRoundSeats(
             @RequestHeader("X-USER-SQ") Long userSq,
-            @RequestBody List<Long> roundSeatSqs
+            @RequestBody SeatReserveRequest request
     );
 
     @PostMapping("/round-seats/details")
-    List<RoundSeatResponse> findRoundSeats(@RequestBody List<Long> roundSeatSqs);
+    List<RoundSeatResponse> findRoundSeats(
+            @RequestBody SeatReserveRequest request
+    );
 }

--- a/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/global/client/dto/request/SeatReserveRequest.java
+++ b/FLOWIN/payment-service/src/main/java/io/why503/paymentservice/global/client/dto/request/SeatReserveRequest.java
@@ -1,0 +1,8 @@
+package io.why503.paymentservice.global.client.dto.request;
+
+import java.util.List;
+
+public record SeatReserveRequest(
+        List<Long> roundSeatSqs
+) {
+}

--- a/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/roundSeat/repository/RoundSeatRepository.java
+++ b/FLOWIN/performance-service/src/main/java/io/why503/performanceservice/domain/roundSeat/repository/RoundSeatRepository.java
@@ -1,34 +1,31 @@
 package io.why503.performanceservice.domain.roundSeat.repository;
 
-import feign.Param;
 import io.why503.performanceservice.domain.round.model.entity.RoundEntity;
-import io.why503.performanceservice.domain.roundSeat.model.enums.RoundSeatStatus;
 import io.why503.performanceservice.domain.roundSeat.model.entity.RoundSeatEntity;
+import io.why503.performanceservice.domain.roundSeat.model.enums.RoundSeatStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-
+import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface RoundSeatRepository extends JpaRepository<RoundSeatEntity,Long> {
-    // 변수명 roundSq가 객체이므로, 그 안의 ID를 찾기 위해 _RoundSq 추가
-    //특정 회차의 모든 좌석 조회
+public interface RoundSeatRepository extends JpaRepository<RoundSeatEntity, Long> {
+
+    // 특정 회차의 모든 좌석 조회
     List<RoundSeatEntity> findByRound_Sq(Long roundSq);
 
-    //특정 회차의 특정 상태인 좌석만 조회
+    // 특정 회차의 특정 상태인 좌석만 조회
     List<RoundSeatEntity> findByRound_SqAndStatus(Long roundSq, RoundSeatStatus roundSeatStatus);
 
-    //특정 회차에 특정좌석SQ를 자진 데이터가 존재하는지 확인
+    // 특정 회차에 특정좌석SQ를 가진 데이터가 존재하는지 확인
     boolean existsByRoundAndShowSeatSq(RoundEntity round, Long showSeatSq);
 
-    //좌석의 상태를 기준으로 좌석 리스트를 가져옴
+    // 좌석의 상태를 기준으로 좌석 리스트를 가져옴
     List<RoundSeatEntity> findAllByStatus(RoundSeatStatus status);
 
     // Bulk Update + 낙관적 락 수동 적용
-    // DB 쿼리 1방으로 처리 (성능 최적화)
-    // version을 1 증가시켜 JPA 낙관적 락 메커니즘 유지
-    @Modifying(clearAutomatically = true) // 쿼리 실행 후 영속성 컨텍스트 초기화 (필수)
+    @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE RoundSeatEntity r
             SET r.status = :newStatus,
@@ -37,12 +34,14 @@ public interface RoundSeatRepository extends JpaRepository<RoundSeatEntity,Long>
             WHERE r.sq IN :ids
               AND r.status = :oldStatus
             """)
-    int updateStatusBulk(@Param("ids") List<Long> ids,
-                         @Param("newStatus") RoundSeatStatus newStatus,
-                         @Param("oldStatus") RoundSeatStatus oldStatus,
-                         @Param("now") LocalDateTime now);
+    int updateStatusBulk(
+            @Param("ids") List<Long> ids,
+            @Param("newStatus") RoundSeatStatus newStatus,
+            @Param("oldStatus") RoundSeatStatus oldStatus,
+            @Param("now") LocalDateTime now
+    );
 
-    //선점된지 10분 지난 좌석을 일괄 해제
+    // 선점된지 10분 지난 좌석을 일괄 해제
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE RoundSeatEntity r

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/booking/listener/BookingPaidAfterCommitListener.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/booking/listener/BookingPaidAfterCommitListener.java
@@ -1,0 +1,33 @@
+package io.why503.reservationservice.domain.booking.listener;
+
+import io.why503.reservationservice.domain.entry.service.EntryTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 결제 확정 이후(트랜잭션 커밋 이후) entry token을 회수하는 리스너
+ *
+ * - confirmPaid()에서 publish한 이벤트를 수신
+ * - commit 이후에 entry token을 delete 해서 del 이벤트를 발생시킨다
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingPaidAfterCommitListener {
+
+    private final EntryTokenService entryTokenService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPaid(BookingPaidEvent event) {
+
+        Long userSq = event.userSq();
+
+        // 결제 완료가 확정된 뒤에만 token 회수
+        entryTokenService.revokeByUserSq(userSq);
+
+        log.info("booking paid -> entry token revoke done. userSq={}", userSq);
+    }
+}

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/booking/listener/BookingPaidEvent.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/booking/listener/BookingPaidEvent.java
@@ -1,0 +1,11 @@
+package io.why503.reservationservice.domain.booking.listener;
+/**
+ * 예매 결제 완료 이벤트
+ *
+ * - confirmPaid()에서 발행
+ * - AFTER_COMMIT 리스너에서 수신
+ * - entry token revokeByUserSq(userSq) 호출 트리거용
+ */
+public record BookingPaidEvent(
+        Long userSq
+) { }

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/listener/EntryTokenDeletedSubscriber.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/listener/EntryTokenDeletedSubscriber.java
@@ -1,0 +1,51 @@
+package io.why503.reservationservice.domain.entry.listener;
+
+import io.why503.reservationservice.domain.queue.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * 퇴장 트리거 (DEL 이벤트용)
+ * 사용 기술 스택 : Redis Keyspace Notification
+ *  리스너를 통해 entry Token 삭제(del) 이벤트 수신
+ *
+ * ※ 결제 완료 시 entry token을 직접 delete 하면
+ *    __keyevent@0__:del 이벤트가 발생하고 여기서 감지한다.
+ */
+@Component
+@RequiredArgsConstructor
+// MessageListener가 뭐냐? : Redis pub/sub 이나 keyspace 이벤트 받을 수 있는 인터페이스
+public class EntryTokenDeletedSubscriber implements MessageListener {
+
+    private final QueueService queueService;
+
+    @Override
+    // DEL 이벤트 감지하면 onMessage에서 트리거 해주는 역할
+    public void onMessage(Message message, byte[] pattern) {
+
+        // 삭제된 Redis Key 문자열
+        String deletedKey = new String(message.getBody());
+
+        // entry token 삭제가 아니다?
+        if (!deletedKey.startsWith("entry:round:")) {
+            return;
+        }
+
+        try {
+            // 키 형식 : entry:round:{roundSq}:user:{userSq}
+            String[] parts = deletedKey.split(":");
+
+            Long roundSq = Long.parseLong(parts[2]);
+            Long userSq = Long.parseLong(parts[4]);
+
+            // DEL된 유저를 active 집합에서 제거
+            // leaveActive에서 promote 이벤트 발행
+            queueService.leaveActive(roundSq, userSq);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/service/EntryTokenService.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/service/EntryTokenService.java
@@ -5,4 +5,7 @@ public interface EntryTokenService {
 
     // entryToken 발급
     String issue(Long userSq, Long roundSq);
+
+    // userSq 기준으로 entryToken 삭제
+    void revokeByUserSq(Long userSq);
 }

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/service/impl/RedisEntryTokenService.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/domain/entry/service/impl/RedisEntryTokenService.java
@@ -1,15 +1,21 @@
 package io.why503.reservationservice.domain.entry.service.impl;
 
 import io.why503.reservationservice.domain.entry.service.EntryTokenService;
+
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.stereotype.Service;
 
-/**
- * Active로 전환된 유저에게 entry token 발급
- */
+// Active로 전환된 유저에게 entry token 발급
 @Service
 @RequiredArgsConstructor
 public class RedisEntryTokenService implements EntryTokenService {
@@ -17,11 +23,16 @@ public class RedisEntryTokenService implements EntryTokenService {
     private final StringRedisTemplate redisTemplate;
 
     // 고정 TTL (메모사항 ::: 나중에 설정값으로 분리계획)
-    private static final Duration TTL = Duration.ofMinutes(1);
+    private static final Duration TTL = Duration.ofMinutes(100);
 
     // userSq 넣은 이유 : TTL 만료 시 expired 이벤트에서 user를 식별할 수 있기에 넣었음
     private static String key(Long roundSq, Long userSq) {
         return "entry:round:" + roundSq + ":user:" + userSq;
+    }
+
+    // active key (RedisQueueServiceImpl 과 동일 규칙)
+    private static String activeKey(Long roundSq) {
+        return "active:round:" + roundSq;
     }
 
     // 토큰 발급
@@ -36,5 +47,81 @@ public class RedisEntryTokenService implements EntryTokenService {
 
         return token;
     }
-    
+
+    // 토큰 회수
+    @Override
+    public void revokeByUserSq(Long userSq) {
+
+        if (userSq == null || userSq <= 0) {
+            return;
+        }
+
+        // entry:round:*:user:{userSq} 패턴으로 scan
+        String pattern = "entry:round:*:user:" + userSq;
+
+        Set<String> keys = scanKeys(pattern);
+
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        // 1) 키가 1개면 그대로 삭제
+        if (keys.size() == 1) {
+            String onlyKey = keys.iterator().next();
+            redisTemplate.delete(onlyKey);
+            return;
+        }
+
+        // 2) 키가 여러 개면 active set에 실제로 들어있는 roundSq를 우선 선택해서 삭제
+        for (String k : keys) {
+            Long roundSq = parseRoundSqFromEntryKey(k);
+            if (roundSq == null) continue;
+
+            Boolean isActive = redisTemplate.opsForSet()
+                    .isMember(activeKey(roundSq), String.valueOf(userSq));
+
+            if (Boolean.TRUE.equals(isActive)) {
+                redisTemplate.delete(k);
+                return;
+            }
+        }
+
+        // 3) 그래도 특정 못하면 안전하게 삭제하지 않는다 (오삭제 방지)
+        // 필요하면 여기서 로그만 남기거나, 정책적으로 1개를 선택해 삭제하도록 변경 가능
+    }
+
+    // SCAN 기반으로 키를 모은다 (KEYS 사용 금지)
+    private Set<String> scanKeys(String pattern) {
+
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(pattern)
+                .count(200)
+                .build();
+
+        return redisTemplate.execute((RedisCallback<Set<String>>) (RedisConnection connection) -> {
+
+            Set<String> results = new HashSet<>();
+
+            try (var cursor = connection.scan(options)) {
+                while (cursor.hasNext()) {
+                    byte[] raw = cursor.next();
+                    results.add(new String(raw, StandardCharsets.UTF_8));
+                }
+            }
+
+            return results;
+        });
+    }
+
+    // entry:round:{roundSq}:user:{userSq} 에서 roundSq 파싱
+    private Long parseRoundSqFromEntryKey(String key) {
+        try {
+            String[] parts = key.split(":");
+            // [entry, round, {roundSq}, user, {userSq}]
+            if (parts.length < 5) return null;
+            return Long.parseLong(parts[2]);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/PerformanceClient.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/PerformanceClient.java
@@ -1,5 +1,6 @@
 package io.why503.reservationservice.global.client;
 
+import io.why503.reservationservice.global.client.dto.request.SeatReserveRequest;
 import io.why503.reservationservice.global.client.dto.response.RoundSeatResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
@@ -27,21 +28,24 @@ public interface PerformanceClient {
     @PostMapping("/round-seats/reserve")
     List<RoundSeatResponse> reserveRoundSeats(
             @RequestHeader("X-USER-SQ") Long userSq,
-            @RequestBody List<Long> roundSeatSqs
+            @RequestBody SeatReserveRequest request
     );
 
     // 결제 미이행 또는 예매 철회 시 점유 중인 좌석 자원을 다시 판매 가능 상태로 방출
     @PostMapping("/round-seats/cancel")
-    void cancelRoundSeats(@RequestBody List<Long> roundSeatSqs);
+    void cancelRoundSeats(
+            @RequestHeader("X-USER-SQ") Long userSq,
+            @RequestBody SeatReserveRequest request
+    );
 
     // 결제 승인 완료에 따른 좌석의 최종 소유권 확정 및 판매 완료 처리
     @PostMapping("/round-seats/confirm")
     void confirmRoundSeats(
             @RequestHeader("X-USER-SQ") Long userSq,
-            @RequestBody List<Long> roundSeatSqs
+            @RequestBody SeatReserveRequest request
     );
 
     // 다건의 좌석 식별자를 기반으로 공연 정보 및 가격 상세 데이터 추출
     @PostMapping("/round-seats/details")
-    List<RoundSeatResponse> findRoundSeats(@RequestBody List<Long> roundSeatSqs);
+    List<RoundSeatResponse> findRoundSeats(@RequestBody SeatReserveRequest request);
 }

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/dto/request/SeatReserveRequest.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/dto/request/SeatReserveRequest.java
@@ -1,0 +1,7 @@
+package io.why503.reservationservice.global.client.dto.request;
+import java.util.List;
+public record SeatReserveRequest(
+        List<Long> roundSeatSqs
+) {
+    
+}

--- a/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/dto/response/RoundSeatResponse.java
+++ b/FLOWIN/reservation-service/src/main/java/io/why503/reservationservice/global/client/dto/response/RoundSeatResponse.java
@@ -2,9 +2,12 @@ package io.why503.reservationservice.global.client.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * 외부 공연 서비스로부터 수신한 좌석 및 공연 정보
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record RoundSeatResponse(
         Long roundSeatSq,
         String roundSeatStatus,


### PR DESCRIPTION
# 1. 예매 완료 시 entryToken 회수 로직 추가 
### 변경 배경
- 기존에는 결제 완료 이후에도 active 집합에 사용자가 남아 있음
- EntryToken TTL 만료까지 대기해야 active가 감소
### 변경 내용
- 예매 결제 완료 시 BookingPaidEvent 발행
- 토큰 즉시 삭제
- 토큰이 삭제되고 active가 감소되어 다음 대기자가 진입 가능되게끔 설계완료
- 
### Redis Keyspace 설정
 config get notify-keyspace-events / config set notify-keyspace-events Egx 켜야 이벤트 수신가능 
 *  E: Keyevent 이벤트
 *  x: expired
 *  g: generic(del 포함)
 
현재 EntryToken 회수 시 active 감소 이벤트 정상 동작 확인 완료.

# 2. performance-service 변경에 따른 Feign 정렬
### performance-service의 round-seat API가 다음과 같이 변경됨:
- 기존 List<Long>
- 변경 : SeatReserveRequest (( { roundSeatSqs: List<Long> } record로 담겨있음))

### 반영내용
다음 서비스에서 Feign 호출 방식들 수정

### 추가로 RoundSeatRepoistory Param 라이브러리 잘못 작성된거 수정
기존 : import feign.Param;
수정 : import org.springframework.data.repository.query.Param;
